### PR TITLE
unused_imports fix by suggestion

### DIFF
--- a/src/backend/compiler/comptime_variable_checker/comptime_context.rs
+++ b/src/backend/compiler/comptime_variable_checker/comptime_context.rs
@@ -1,4 +1,3 @@
-use crate::backend::ast::statements::functions::args_node::FunctionArgs;
 use crate::backend::compiler::comptime_variable_checker::comptime_value_for_check::ComptimeValueType;
 use crate::backend::compiler::functions_compiler_context::CompileTimeFunctionForCheck;
 use crate::backend::errors::compiler::compiler_errors::CompileError;


### PR DESCRIPTION
```
  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: `flare` (lib) generated 1 warning (run `cargo fix --lib -p flare` to apply 1 suggestion)
    Finished `release` profile [optimized] target(s) in 2.50s
PS C:\Users\kravac01\work\Šimon\Flare> cargo fix --lib -p flare
    Checking flare v0.0.14 (C:\Users\kravac01\work\Šimon\Flare)
       Fixed src\backend\compiler\comptime_variable_checker\comptime_context.rs (1 fix)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.61s
```