### PR TITLE
Fix output directory creation

### DIFF
--- a/src/backend/saving_bytes/compile_tools.rs
+++ b/src/backend/saving_bytes/compile_tools.rs
@@ -9,10 +9,7 @@ use crate::clrprintln;
 use crate::backend::linker::obj_file::ObjFile;
 use crate::backend::saving_bytes::save::compile_instr_to_bytes;
 use std::{
-    fs,
-    path::{Path, PathBuf},
-    process,
-    time::Instant,
+ fs,  path::{Path, PathBuf}, process, time::Instant
 };
 use walkdir::WalkDir;
 fn debug_print(tokens: &Vec<Token>, ast: Box<dyn Compilable>, instructions: &Vec<Instructions>) {
@@ -200,7 +197,11 @@ pub fn main() !void {{
 
     let tmp_launcher_path = "tmp_launcher.zig";
     fs::write(tmp_launcher_path, temp_launcher).unwrap();
+
+   
+
     let runtime_path = find_libvm_runtime(Path::new(".")).unwrap();
+    
     let status = Command::new("zig")
         .args(&[
             "build-exe",
@@ -232,8 +233,9 @@ pub fn main() !void {{
 
 fn ensure_target_dir() {
     let target = std::env::current_dir().unwrap().join("out/bin");
-    if !target.exists() {
-        fs::create_dir(target).expect("Cannot create target directory");
+   
+    if !&target.exists() {
+        fs::create_dir_all(target).expect("Could not create the binary output directory");
     }
 }
 

--- a/src/bin/vertex.rs
+++ b/src/bin/vertex.rs
@@ -61,7 +61,7 @@ fn run_cli() -> Result<(), CommandLineError> {
                 "#
                 );
             }
-            "create" => {
+            "new" => {
                 if let Some(project_name) = args.get(2) {
                     // TODO: Add appropriate directory
                     fs::create_dir(&project_name)


### PR DESCRIPTION
Found a bug where the creation of the output dir fails because of using the wrong rust function create_dir instead of create_dir_all, also the vertex new command was set to be vertex create in the code, also updated that


thread 'main' (1372638) panicked at src/backend/saving_bytes/compile_tools.rs:237:32:
Cannot create target directory: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace